### PR TITLE
feat: Use shorthand flags for BusyBox sort compatibility

### DIFF
--- a/prsync
+++ b/prsync
@@ -44,7 +44,7 @@ echo -e "${GREEN}INFO: Determining file list for transfer ...${NC}"
 # sorted by size (descending)
 rsync "$@" --out-format="%l %n" --no-v --dry-run 2> /dev/null \
   | grep -v "sending incremental file list" \
-  | sort --numeric-sort --reverse \
+  | sort -n -r \
   > "${TMPDIR}/files.all"
 
 # check for nothing-to-do


### PR DESCRIPTION
The GNU `sort` program [explicitly supports](https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html) both the long `--numeric-sort` and `--reverse` flags, and the shorthand `-n` and `-r` flags. However, BusyBox `sort` [only supports shorthand](https://boxmatrix.info/wiki/Property:sort) `-n` and `-r` flags. This changes should allow for compatibility with both sort programs so that `prsync` runs on distributions with BusyBox such as Alpine Linux.